### PR TITLE
Finally fixed CI

### DIFF
--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -11,18 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: docker://manifoldai/orbyter-ml-dev:2.0
+      image: docker://python/3.8.8-slim-buster
     
     steps:
     - uses: actions/checkout@v2
-    # - name: Set up Python 3.8
-    #   uses: actions/setup-python@v1 
-    #   with:
-    #     python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest==6.2.2
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v1 
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -24,5 +24,5 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        cd /home/runner/work/PandasTransform/
+        ls
         pytest

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: docker://python/3.8.8-slim-buster
+      image: docker://python
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v1
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -26,5 +26,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        cd /home/runner/work/PandasTransform/PandasTransform
         pytest

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -10,13 +10,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: docker://manifoldai/orbyter-ml-dev:2.0
     
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1 
-      with:
-        python-version: 3.8
+    # - name: Set up Python 3.8
+    #   uses: actions/setup-python@v1 
+    #   with:
+    #     python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -10,16 +10,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: docker://python
     
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2 
+      with:
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest==6.2.2
+        python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
+        cd /home/runner/work/PandasTransform/
         pytest

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -24,4 +24,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        pytest
+        python -m pytest mypackage/

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -24,4 +24,5 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
+        cd /home/runner/work/PandasTransform/PandasTransform
         pytest

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -5,7 +5,7 @@ name: Automatic unit tests
 
 on:
   push:
-    branches: [ main ]    
+    branches: [ main, fixing_pytest_ci ]    
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v1
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -24,4 +24,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        python -m pytest mypackage/
+        python -m pytest

--- a/.github/workflows/github_autotest.yaml
+++ b/.github/workflows/github_autotest.yaml
@@ -24,5 +24,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        ls
         pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-# pytest.ini
-[pytest]
-python_files = test_*.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 # pytest.ini
 [pytest]
 python_files = test_*.py
-addopts = -rf --import-mode=importlib

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,4 @@
 # pytest.ini
 [pytest]
-testpaths =
-    tests
 python_files = test_*.py
 addopts = -rf --import-mode=importlib


### PR DESCRIPTION
Tried pulling custom Docker images, tried fiddling with pytest.ini ... It turns out the key is to run pytest not as a terminal command, but as `python -m pytest`. [Apparently](https://docs.pytest.org/en/stable/usage.html), 

> This is almost equivalent to invoking the command line script pytest [...] directly, except that calling via python will also add the current directory to sys.path.